### PR TITLE
Avoid deprecation warnings in Rails 3

### DIFF
--- a/lib/prawnto/template_handlers/base.rb
+++ b/lib/prawnto/template_handlers/base.rb
@@ -1,7 +1,7 @@
 module Prawnto
   module TemplateHandlers
-    class Base < ::ActionView::TemplateHandler
-      include ::ActionView::TemplateHandlers::Compilable
+    class Base < (::Rails::VERSION::MAJOR < 3 ? ::ActionView::TemplateHandler : ::Object)
+      include ::ActionView::TemplateHandlers::Compilable if ::Rails::VERSION::MAJOR < 3
       
       def compile(template)
         "_prawnto_compile_setup;" +

--- a/prawnto.gemspec
+++ b/prawnto.gemspec
@@ -1,0 +1,20 @@
+Gem::Specification.new do |s|
+  s.name = %q{prawnto}
+  s.version = "2.0.1"
+  s.required_rubygems_version = ">= 1.3.6"
+
+  s.authors = ['Some Body']
+  s.email   = ['some@body.com']
+  s.date = '2011-09-13'
+
+  s.homepage = %q{http://github.com/comverge/prawnto}
+  s.summary = %q{PDF views}
+  s.description = %q{PDF views}
+
+  exclude_folders = 'spec/rails/{doc,lib,log,nbproject,tmp,vendor,test}'
+  exclude_files = Dir['**/*.log'] + Dir[exclude_folders+'/**/*'] + Dir[exclude_folders]
+  s.files = Dir['{examples,lib,tasks,spec}/**/*'] +
+    %w(CHANGELOG LICENSE README.markdown init.rb) -
+    exclude_files
+  s.require_paths = ["lib"]
+end

--- a/prawnto.gemspec
+++ b/prawnto.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
 
   exclude_folders = 'spec/rails/{doc,lib,log,nbproject,tmp,vendor,test}'
   exclude_files = Dir['**/*.log'] + Dir[exclude_folders+'/**/*'] + Dir[exclude_folders]
-  s.files = Dir['{examples,lib,tasks,spec}/**/*'] +
-    %w(CHANGELOG LICENSE README.markdown init.rb) -
+  s.files = Dir['{examples,lib,tasks,spec}/**/*'] -
     exclude_files
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
This simple fix avoids deprecation warnings like this:

```
DEPRECATION WARNING: Inheriting from ActionView::Template::Handler is deprecated. Since Rails 3, all the API your template handler needs to implement is to respond to #call.
```
