### PR TITLE
Get rid of warning message when starting Rails 3.2.3

### DIFF
--- a/lib/prawnto.rb
+++ b/lib/prawnto.rb
@@ -18,7 +18,7 @@ module Prawnto
     def enable
       ActionController::Base.send :include, Prawnto::ActionControllerMixin
       ActionView::Base.send :include, Prawnto::ActionViewMixin
-      Mime::Type.register "application/pdf", :pdf
+      Mime::Type.register "application/pdf", :pdf unless Mime::Type.lookup_by_extension(:pdf)
       ActionView::Template.register_template_handler 'prawn', Prawnto::TemplateHandlers::Base
       ActionView::Template.register_template_handler 'prawn_dsl', Prawnto::TemplateHandlers::Dsl
       ActionView::Template.register_template_handler 'prawn_xxx', Prawnto::TemplateHandlers::Raw  


### PR DESCRIPTION
Get rid of warning message when starting Rails 3.2.3 by checking if PDF mime type is already defined.

=> Rails 3.2.3 application starting in development on http://0.0.0.0:3000
=> Call with -d to detach
=> Ctrl-C to shutdown server
/var/lib/gems/1.9.1/gems/actionpack-3.2.3/lib/action_dispatch/http/mime_type.rb:102: warning: already initialized constant PDF
