### PR TITLE
Wrap the filenames with quotes for the Content-Disposition header

### DIFF
--- a/lib/prawnto/template_handler/compile_support.rb
+++ b/lib/prawnto/template_handler/compile_support.rb
@@ -57,7 +57,7 @@ module Prawnto
 
       def set_disposition
         inline = options[:inline] ? 'inline' : 'attachment'
-        filename = options[:filename] ? "filename=#{options[:filename]}" : nil
+        filename = options[:filename] ? "filename=\"#{options[:filename]}\"" : nil
         @controller.headers["Content-Disposition"] = [inline,filename].compact.join(';')
       end
 


### PR DESCRIPTION
So that filenames with commas don't cause "Duplicate headers received from server" error in Chromium-based browsers.

See also:
- https://groups.google.com/forum/#!topic/web2py/paweofnBz-g
- http://stackoverflow.com/questions/10120197/nginx-rails-send-file-duplicate-headers-received-from-server
- https://github.com/prior/prawnto/pull/16
- https://github.com/prior/prawnto/commit/fddf4fa257c62ca87cbcde0cdc449f9d1c084c6e
